### PR TITLE
Added sensor type in name

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,4 @@
-""" 
+"""
 Copyright 2022 Silicon Laboratories, www.silabs.com
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -65,7 +65,7 @@ async def async_setup_entry(hass: HomeAssistant, config: ConfigEntry) -> bool:
                     pass
             # sensors
             discovery_info["clusters"] = []
-            if "Scenes" in endpoint.clusters:
+            if "Scenes" in endpoint.clusters and "RecallScene" in endpoint.clusters["Scenes"].supported_commands:
                 discovery_info["clusters"].append("scenes")
             if "TemperatureMeasurement" in endpoint.clusters:
                 discovery_info["clusters"].append("temperaturemeasurement")

--- a/base_unify_entity.py
+++ b/base_unify_entity.py
@@ -1,4 +1,4 @@
-""" 
+"""
 Copyright 2022 Silicon Laboratories, www.silabs.com
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -144,11 +144,13 @@ class BaseUnifyState(Entity):
 
 class BaseUnifyEntity(BaseUnifySupportedCommands, BaseUnifyState):
     """Encapsulates all the base capabilities of a Unify device"""
+    _attr_has_entity_name: bool = True
 
-    def __init__(self, hass, unid, endpoint):
+    def __init__(self, hass, unid, endpoint, entity_type=""):
         self._hass = hass
         self._unid = unid
         self._ep = endpoint
+        self._entity_type = entity_type
         self.added_device = False
         self._async_mqtt_remove = []
         self._name = hass.data[DOMAIN][NODE_STATE_MONITOR].nodes[self._unid].endpoints[self._ep].name
@@ -157,7 +159,13 @@ class BaseUnifyEntity(BaseUnifySupportedCommands, BaseUnifyState):
     @ property
     def name(self):
         """Return the name of the device."""
-        return self._name or self.unique_id
+        if self._name:
+            if self._entity_type:
+                return self._entity_type + "_" + self._name
+            else:
+                return self._name
+        else:
+            return self.unique_id
 
     @ property
     def force_update(self):

--- a/light.py
+++ b/light.py
@@ -1,4 +1,4 @@
-""" 
+"""
 Copyright 2022 Silicon Laboratories, www.silabs.com
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/sensor.py
+++ b/sensor.py
@@ -1,4 +1,4 @@
-""" 
+"""
 Copyright 2022 Silicon Laboratories, www.silabs.com
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -63,7 +63,7 @@ class UnifyTemperature(SensorEntity, BaseUnifyEntity):
     """Representation of a Unify Temperature Sensor."""
 
     def __init__(self, hass, unid, endpoint):
-        BaseUnifyEntity.__init__(self, hass, unid, endpoint)
+        BaseUnifyEntity.__init__(self, hass, unid, endpoint, 'temperature')
         _LOGGER.info("UnifyTemperature: Init")
         self._native_value = 0
         self._device_class = DEVICE_CLASS_TEMPERATURE
@@ -82,7 +82,7 @@ class UnifyTemperature(SensorEntity, BaseUnifyEntity):
         temp = int(parsed_msg["value"]) / 100
         _LOGGER.info(
             "UnifyTemperature: state changed for %s to %s Payload %s ",
-            self._name,
+            self.name,
             msg.topic,
             parsed_msg,
         )
@@ -123,7 +123,7 @@ class UnifyScene(SensorEntity, BaseUnifyEntity):
     """Representation of a Unify Scene."""
 
     def __init__(self, hass, unid, endpoint):
-        BaseUnifyEntity.__init__(self, hass, unid, endpoint)
+        BaseUnifyEntity.__init__(self, hass, unid, endpoint, 'scene')
         self._native_value = ""
         self._device_class = ""
         self._native_unit_of_measurement = ""
@@ -139,7 +139,7 @@ class UnifyScene(SensorEntity, BaseUnifyEntity):
         parsed_msg = json.loads(msg.payload)
         _LOGGER.info(
             "UnifyScene: state changed for %s to %s Payload %s ",
-            self._name,
+            self.name,
             msg.topic,
             parsed_msg,
         )
@@ -180,7 +180,7 @@ class UnifyBattery(SensorEntity, BaseUnifyEntity):
 
     def __init__(self, hass, unid, endpoint):
         _LOGGER.info("UnifyBattery: Init")
-        BaseUnifyEntity.__init__(self, hass, unid, endpoint)
+        BaseUnifyEntity.__init__(self, hass, unid, endpoint, 'battery')
         self._native_value = 100
         self._device_class = DEVICE_CLASS_BATTERY
         self._native_unit_of_measurement = PERCENTAGE
@@ -197,7 +197,7 @@ class UnifyBattery(SensorEntity, BaseUnifyEntity):
             parsed_msg = json.loads(msg.payload)
             _LOGGER.info(
                 "UnifyBattery: state changed for %s to %s Payload %s ",
-                self._name,
+                self.name,
                 msg.topic,
                 parsed_msg,
             )

--- a/switch.py
+++ b/switch.py
@@ -1,4 +1,4 @@
-""" 
+"""
 Copyright 2022 Silicon Laboratories, www.silabs.com
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -48,8 +48,6 @@ async def async_setup_platform(
 
 class UnifyOnOff(SwitchEntity, BaseUnifyEntity):
     """Representation of a Unify Switch."""
-    _attr_has_entity_name = True
-    _attr_name = None
 
     def __init__(self, hass, unid, endpoint):
         self._is_on = False


### PR DESCRIPTION
Added Sensor Type in names, so if you have an endpoint with multiple sensors, e.g. temperature and battery you now get names 'sensor.battery_<name>' and 'sensor.temperature_<name>' instead of 'sensor.<name>_1' and 'sensor.<name>_2'

Fixed issue with invalid scene devices popping up on in HA