### PR TITLE
Fixed node state issues and missing light level state update

### DIFF
--- a/base_unify_entity.py
+++ b/base_unify_entity.py
@@ -1,14 +1,9 @@
 """
 Copyright 2022 Silicon Laboratories, www.silabs.com
-
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-
 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
@@ -69,18 +64,6 @@ def find_unid(topic: str) -> str:
         raise ValueError(
             f"More or less than 1 unids found in MQTT topic in device: {topic}")
     return found_unids[0]
-
-
-def setup_device_data_structure(unid: str, endpoint: str, devices: dict):
-    if unid not in devices:
-        devices[unid] = {}
-        devices[unid][endpoint] = {}
-        return devices
-
-    if endpoint not in devices[unid]:
-        devices[unid][endpoint] = {}
-
-    return devices
 
 
 def get_hass_endpoint(hass: HomeAssistant, node: Node, endpoint: Endpoint):

--- a/binary_sensor.py
+++ b/binary_sensor.py
@@ -1,14 +1,9 @@
 """
 Copyright 2022 Silicon Laboratories, www.silabs.com
-
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-
 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
@@ -18,7 +13,7 @@ import json
 from typing import final
 
 # Integration components
-from .base_unify_entity import BaseUnifyEntity, setup_device_data_structure
+from .base_unify_entity import BaseUnifyEntity
 from .const import DOMAIN, DEVICES
 
 # HA packages
@@ -39,7 +34,6 @@ async def async_setup_platform(
         discovery_info=None):
     unid = discovery_info["unid"]
     endpoint = discovery_info["endpoint"]
-    setup_device_data_structure(unid, endpoint, hass.data[DOMAIN][DEVICES])
     hass.data[DOMAIN][DEVICES][unid][endpoint]["binary_sensor"] = UnifyOccupancySensing(
         hass, unid, endpoint)
     device = hass.data[DOMAIN][DEVICES][unid][endpoint]["binary_sensor"]
@@ -91,7 +85,6 @@ class UnifyOccupancySensing(BinarySensorEntity, BaseUnifyEntity):
             self.async_schedule_update_ha_state(False)
         except Exception as err:
             _LOGGER.error("BinarySensor: Exception on State Update: %s", err)
-
 
     async def _on_message_state(self, message: ReceiveMessage):
         _LOGGER.debug("BinarySensor: state changed for %s to %s ",

--- a/config_flow.py
+++ b/config_flow.py
@@ -1,14 +1,9 @@
-""" 
+"""
 Copyright 2022 Silicon Laboratories, www.silabs.com
-
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-
 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 

--- a/const.py
+++ b/const.py
@@ -1,14 +1,9 @@
-""" 
+"""
 Copyright 2022 Silicon Laboratories, www.silabs.com
-
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-
 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 

--- a/lock.py
+++ b/lock.py
@@ -1,14 +1,9 @@
 """
 Copyright 2022 Silicon Laboratories, www.silabs.com
-
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-
 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
@@ -18,7 +13,7 @@ import json
 from typing import final
 
 # Integration components
-from .base_unify_entity import BaseUnifyEntity, setup_device_data_structure
+from .base_unify_entity import BaseUnifyEntity
 from .const import DOMAIN, DEVICES
 
 # HA packages
@@ -40,7 +35,6 @@ async def async_setup_platform(
 ):
     unid = discovery_info["unid"]
     endpoint = discovery_info["endpoint"]
-    setup_device_data_structure(unid, endpoint, hass.data[DOMAIN][DEVICES])
     hass.data[DOMAIN][DEVICES][unid][endpoint]["lock"] = UnifyLock(hass, unid, endpoint)
     device = hass.data[DOMAIN][DEVICES][unid][endpoint]["lock"]
     async_add_entities([device])

--- a/node_state_monitor.py
+++ b/node_state_monitor.py
@@ -1,14 +1,9 @@
-""" 
+"""
 Copyright 2022 Silicon Laboratories, www.silabs.com
-
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-
 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
@@ -234,7 +229,7 @@ class NodeStateMonitor():
         old_state = node.state
         node.state = message.payload
 
-        if not node.added and self._async_on_node_added and not hasattr(node, 'node_added_timer'):
+        if not node.added and self._async_on_node_added:
             async def timeout_callback():
                 if time.time() - node.last_update > 1:
                     node.node_added_timer = None
@@ -244,7 +239,8 @@ class NodeStateMonitor():
                 else:
                     _LOGGER.info("Starting node_added_timer")
                     node.node_added_timer = Timer(1, timeout_callback)
-            await timeout_callback()
+            if not hasattr(node, 'node_added_timer') and node.state == "Online functional":
+                await timeout_callback()
         else:
             if self._async_on_state_changed:
                 await self._async_on_state_changed(node, old_state, node.state)

--- a/sensor.py
+++ b/sensor.py
@@ -1,21 +1,16 @@
 """
 Copyright 2022 Silicon Laboratories, www.silabs.com
-
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-
 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 import json
 import logging
 from typing import final
-from .base_unify_entity import BaseUnifyEntity, setup_device_data_structure
+from .base_unify_entity import BaseUnifyEntity
 from .const import DOMAIN, DEVICES
 from homeassistant.components.mqtt.models import ReceiveMessage
 from homeassistant.components.sensor import SensorEntity
@@ -42,7 +37,6 @@ async def async_setup_platform(
         return
     unid = discovery_info["unid"]
     endpoint = discovery_info["endpoint"]
-    setup_device_data_structure(unid, endpoint, hass.data[DOMAIN][DEVICES])
     devices = []
     if "temperaturemeasurement" in discovery_info["clusters"]:
         hass.data[DOMAIN][DEVICES][unid][endpoint]["temperaturemeasurement"] = UnifyTemperature(

--- a/switch.py
+++ b/switch.py
@@ -1,14 +1,9 @@
 """
 Copyright 2022 Silicon Laboratories, www.silabs.com
-
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-
 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
@@ -18,7 +13,7 @@ import json
 from typing import final
 
 # Integration components
-from .base_unify_entity import BaseUnifyEntity, setup_device_data_structure
+from .base_unify_entity import BaseUnifyEntity
 from .const import DOMAIN, DEVICES
 
 # HA packages
@@ -39,7 +34,6 @@ async def async_setup_platform(
         discovery_info=None):
     unid = discovery_info["unid"]
     endpoint = discovery_info["endpoint"]
-    setup_device_data_structure(unid, endpoint, hass.data[DOMAIN][DEVICES])
     hass.data[DOMAIN][DEVICES][unid][endpoint]["switch"] = UnifyOnOff(
         hass, unid, endpoint)
     device = hass.data[DOMAIN][DEVICES][unid][endpoint]["switch"]


### PR DESCRIPTION
Fixed node state (online/offline) issue, when Unify nodes becomes unavailable/available. Fixed missing update of Level in Light, when level was changed from Unify side removed weird newlines in licenses